### PR TITLE
Add HTTP/TLS/SOCKS protocol blocking UI for node management

### DIFF
--- a/go-backend/dto/node.go
+++ b/go-backend/dto/node.go
@@ -20,3 +20,10 @@ type NodeUpdateDto struct {
 	PortEnd   *int    `json:"portEnd"`
 	GroupName *string `json:"groupName"`
 }
+
+type NodeSetProtocolDto struct {
+	ID    int64 `json:"id" binding:"required"`
+	Http  int   `json:"http"`
+	Tls   int   `json:"tls"`
+	Socks int   `json:"socks"`
+}

--- a/go-backend/handler/node.go
+++ b/go-backend/handler/node.go
@@ -62,6 +62,15 @@ func NodeUpdate(c *gin.Context) {
 	c.JSON(http.StatusOK, service.UpdateNode(d))
 }
 
+func NodeSetProtocol(c *gin.Context) {
+	var d dto.NodeSetProtocolDto
+	if err := c.ShouldBindJSON(&d); err != nil {
+		c.JSON(http.StatusOK, dto.Err("参数错误"))
+		return
+	}
+	c.JSON(http.StatusOK, service.SetNodeProtocol(d))
+}
+
 func NodeDelete(c *gin.Context) {
 	var d struct {
 		ID int64 `json:"id" binding:"required"`

--- a/go-backend/router/router.go
+++ b/go-backend/router/router.go
@@ -87,6 +87,7 @@ func Setup(r *gin.Engine) {
 		auth.POST("/node/reconcile", middleware.Admin(), handler.NodeReconcile)
 		auth.POST("/node/update-binary", middleware.Admin(), handler.NodeUpdateBinary)
 		auth.POST("/node/update-order", middleware.Admin(), handler.NodeUpdateOrder)
+		auth.POST("/node/set-protocol", middleware.Admin(), handler.NodeSetProtocol)
 
 		// Tunnel
 		auth.POST("/tunnel/create", middleware.Admin(), handler.TunnelCreate)

--- a/go-backend/service/node.go
+++ b/go-backend/service/node.go
@@ -207,6 +207,43 @@ func UpdateNode(d dto.NodeUpdateDto) dto.R {
 	return dto.Ok("节点更新成功")
 }
 
+func SetNodeProtocol(d dto.NodeSetProtocolDto) dto.R {
+	// Validate values
+	if (d.Http != 0 && d.Http != 1) || (d.Tls != 0 && d.Tls != 1) || (d.Socks != 0 && d.Socks != 1) {
+		return dto.Err("协议屏蔽值必须为 0 或 1")
+	}
+
+	var node model.Node
+	if err := DB.First(&node, d.ID).Error; err != nil {
+		return dto.Err("节点不存在")
+	}
+
+	// Update DB
+	if err := DB.Model(&node).Updates(map[string]interface{}{
+		"http":         d.Http,
+		"tls":          d.Tls,
+		"socks":        d.Socks,
+		"updated_time": time.Now().UnixMilli(),
+	}).Error; err != nil {
+		return dto.Err("更新协议屏蔽失败")
+	}
+
+	// Push to node via WebSocket if online
+	if pkg.WS != nil && pkg.WS.IsNodeOnline(d.ID) {
+		resp := pkg.WS.SendMsg(d.ID, map[string]interface{}{
+			"http":  d.Http,
+			"tls":   d.Tls,
+			"socks": d.Socks,
+		}, "SetProtocol")
+		if resp != nil && resp.Msg != "OK" {
+			log.Printf("SetProtocol push to node %d: %s", d.ID, resp.Msg)
+			return dto.Ok("已保存，但推送到节点失败: " + resp.Msg)
+		}
+	}
+
+	return dto.Ok("协议屏蔽已更新")
+}
+
 func DeleteNode(id int64) dto.R {
 	var node model.Node
 	if err := DB.First(&node, id).Error; err != nil {

--- a/nextjs-frontend/app/(auth)/node/page.tsx
+++ b/nextjs-frontend/app/(auth)/node/page.tsx
@@ -11,11 +11,12 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Plus, Trash2, Edit2, Terminal, Container, Copy, Eye, EyeOff, RefreshCw, ArrowUpDown, Network, Download, Check, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
-import { getNodeList, createNode, updateNode, deleteNode, getNodeInstallCommand, getNodeDockerCommand, reconcileNode, updateNodeBinary } from '@/lib/api/node';
+import { getNodeList, createNode, updateNode, deleteNode, getNodeInstallCommand, getNodeDockerCommand, reconcileNode, updateNodeBinary, setNodeProtocol } from '@/lib/api/node';
 import { switchXrayVersion, getXrayVersions } from '@/lib/api/xray-node';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { getVersion } from '@/lib/api/system';
+import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/lib/hooks/use-auth';
 import { useTranslation } from '@/lib/i18n';
 
@@ -45,6 +46,8 @@ export default function NodePage() {
   const [commandIPv6, setCommandIPv6] = useState(false);
   const [showSecret, setShowSecret] = useState(false);
   const [panelVersion, setPanelVersion] = useState('');
+  const [protocolForm, setProtocolForm] = useState({ http: 0, tls: 0, socks: 0 });
+  const [protocolSaving, setProtocolSaving] = useState(false);
 
   const initialLoad = useRef(true);
 
@@ -149,7 +152,32 @@ export default function NodePage() {
       groupName: node.groupName || '',
     });
     setShowSecret(false);
+    setProtocolForm({ http: node.http || 0, tls: node.tls || 0, socks: node.socks || 0 });
     setDialogOpen(true);
+  };
+
+  const handleProtocolToggle = async (field: 'http' | 'tls' | 'socks', value: boolean) => {
+    if (!editingNode) return;
+    const newForm = { ...protocolForm, [field]: value ? 1 : 0 };
+    setProtocolForm(newForm);
+    setProtocolSaving(true);
+    try {
+      const res = await setNodeProtocol({ id: editingNode.id, ...newForm });
+      if (res.code === 0) {
+        toast.success(t('node.protocolUpdateSuccess'));
+        setNodes(prev => prev.map(n =>
+          n.id === editingNode.id ? { ...n, ...newForm } : n
+        ));
+      } else {
+        toast.error(res.msg || t('node.protocolUpdateFailed'));
+        setProtocolForm(protocolForm); // revert
+      }
+    } catch {
+      toast.error(t('node.protocolUpdateFailed'));
+      setProtocolForm(protocolForm); // revert
+    } finally {
+      setProtocolSaving(false);
+    }
   };
 
   const handleSubmit = async () => {
@@ -553,6 +581,47 @@ export default function NodePage() {
               </div>
               {editingNode && <p className="text-xs text-muted-foreground">{t('node.secretReadonly')}</p>}
             </div>
+            {editingNode && (
+              <div className="space-y-2">
+                <Label>{t('node.protocolBlock')}</Label>
+                {editingNode.status !== 1 ? (
+                  <p className="text-xs text-muted-foreground">{t('node.nodeOfflineCannotSet')}</p>
+                ) : (
+                  <>
+                    <div className="flex items-center gap-6">
+                      <label className="flex items-center gap-2 text-sm">
+                        <Switch
+                          className="scale-90"
+                          checked={protocolForm.http === 1}
+                          onCheckedChange={(v) => handleProtocolToggle('http', v)}
+                          disabled={protocolSaving}
+                        />
+                        HTTP
+                      </label>
+                      <label className="flex items-center gap-2 text-sm">
+                        <Switch
+                          className="scale-90"
+                          checked={protocolForm.tls === 1}
+                          onCheckedChange={(v) => handleProtocolToggle('tls', v)}
+                          disabled={protocolSaving}
+                        />
+                        TLS
+                      </label>
+                      <label className="flex items-center gap-2 text-sm">
+                        <Switch
+                          className="scale-90"
+                          checked={protocolForm.socks === 1}
+                          onCheckedChange={(v) => handleProtocolToggle('socks', v)}
+                          disabled={protocolSaving}
+                        />
+                        SOCKS
+                      </label>
+                    </div>
+                    <p className="text-xs text-muted-foreground">{t('node.protocolBlockDesc')}</p>
+                  </>
+                )}
+              </div>
+            )}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDialogOpen(false)}>{t('common.cancel')}</Button>

--- a/nextjs-frontend/lib/api/node.ts
+++ b/nextjs-frontend/lib/api/node.ts
@@ -15,3 +15,4 @@ export const checkNodeStatus = (nodeId?: number) => post('/node/check-status', n
 export const reconcileNode = (id: number) => post('/node/reconcile', { id });
 export const updateNodeBinary = (id: number) => post('/node/update-binary', { id });
 export const updateNodeOrder = (items: { id: number; inx: number }[]) => post('/node/update-order', { items });
+export const setNodeProtocol = (data: { id: number; http: number; tls: number; socks: number }) => post('/node/set-protocol', data);

--- a/nextjs-frontend/lib/i18n/en.ts
+++ b/nextjs-frontend/lib/i18n/en.ts
@@ -325,6 +325,11 @@ const en: Translations = {
     xrayDisguiseName: 'Xray Disguise',
     groupName: 'Group',
     groupNamePlaceholder: 'e.g. Hong Kong, US',
+    protocolBlock: 'Protocol Blocking',
+    protocolBlockDesc: 'Block specified protocol traffic on this node (node must be online)',
+    protocolUpdateSuccess: 'Protocol blocking updated',
+    protocolUpdateFailed: 'Failed to update protocol blocking',
+    nodeOfflineCannotSet: 'Node is offline, cannot modify protocol blocking',
   },
   user: {
     title: 'User Management',

--- a/nextjs-frontend/lib/i18n/zh.ts
+++ b/nextjs-frontend/lib/i18n/zh.ts
@@ -323,6 +323,11 @@ const zh = {
     xrayDisguiseName: 'Xray 伪装名',
     groupName: '分组',
     groupNamePlaceholder: '例如: 香港、美国',
+    protocolBlock: '协议屏蔽',
+    protocolBlockDesc: '开启后将屏蔽节点上对应协议的流量，需节点在线',
+    protocolUpdateSuccess: '协议屏蔽已更新',
+    protocolUpdateFailed: '协议屏蔽更新失败',
+    nodeOfflineCannotSet: '节点离线，无法修改协议屏蔽设置',
   },
   user: {
     title: '用户管理',


### PR DESCRIPTION
- Backend: new SetNodeProtocol service + NodeSetProtocol handler + POST /node/set-protocol route
- Backend: updates DB and pushes SetProtocol WebSocket command to online nodes in real time
- Frontend: protocol blocking section in edit node dialog with HTTP/TLS/SOCKS switches
- Frontend: switches disabled when node is offline; auto-reverts on API failure
- i18n: Chinese and English translations for new protocol blocking UI